### PR TITLE
Input handling workaround for macOS 10.12 (Sierra)

### DIFF
--- a/garglk/fontmac.m
+++ b/garglk/fontmac.m
@@ -186,7 +186,7 @@ void fontreplace(char *font, int type)
     int style;    
     FSRef fileref;
     ATSFontRef fontref;
-    unsigned char * filebuf;
+    char * filebuf;
 
     while (sysfont = [sysfonts nextObject])
     {

--- a/garglk/sysmac.h
+++ b/garglk/sysmac.h
@@ -1,0 +1,71 @@
+#define NSKEY_LEFT      0x7b
+#define NSKEY_RIGHT     0x7c
+#define NSKEY_DOWN      0x7d
+#define NSKEY_UP        0x7e
+
+#define NSKEY_X         0x07
+#define NSKEY_C         0x08
+#define NSKEY_V         0x09
+
+#define NSKEY_PGUP      0x74
+#define NSKEY_PGDN      0x79
+#define NSKEY_HOME      0x73
+#define NSKEY_END       0x77
+#define NSKEY_DEL       0x75
+#define NSKEY_BACK      0x33
+#define NSKEY_ESC       0x35
+
+#define NSKEY_F1        0x7a
+#define NSKEY_F2        0x78
+#define NSKEY_F3        0x63
+#define NSKEY_F4        0x76
+#define NSKEY_F5        0x60
+#define NSKEY_F6        0x61
+#define NSKEY_F7        0x62
+#define NSKEY_F8        0x64
+#define NSKEY_F9        0x65
+#define NSKEY_F10       0x6d
+#define NSKEY_F11       0x67
+#define NSKEY_F12       0x6f
+
+@protocol GargoyleApp
+
+- (BOOL) initWindow: (pid_t) processID
+              width: (unsigned int) width
+             height: (unsigned int) height;
+
+- (NSEvent *) getWindowEvent: (pid_t) processID;
+
+- (NSRect) getWindowSize: (pid_t) processID;
+
+- (NSString *) getWindowCharString: (pid_t) processID;
+
+- (BOOL) clearWindowCharString: (pid_t) processID;
+
+- (BOOL) setWindow: (pid_t) processID
+        charString: (NSEvent *) event;
+
+- (BOOL) setWindow: (pid_t) processID
+             title: (NSString *) title;
+
+- (BOOL) setWindow: (pid_t) processID
+          contents: (NSData *) frame
+             width: (unsigned int) width
+            height: (unsigned int) height;
+
+- (void) closeWindow: (pid_t) processID;
+
+- (NSString *) openWindowDialog: (pid_t) processID
+                         prompt: (NSString *) prompt
+                         filter: (unsigned int) filter;
+
+- (NSString *) saveWindowDialog: (pid_t) processID
+                         prompt: (NSString *) prompt
+                         filter: (unsigned int) filter;
+
+- (void) abortWindowDialog: (pid_t) processID
+                    prompt: (NSString *) prompt;
+
+- (void) setCursor: (unsigned int) cursor;
+
+@end

--- a/garglk/sysmac.m
+++ b/garglk/sysmac.m
@@ -30,6 +30,7 @@
 #include "garglk.h"
 
 #import "Cocoa/Cocoa.h"
+#import "sysmac.h"
 
 #ifdef __ppc__
 #define ByteOrderUCS4 kCFStringEncodingUTF32
@@ -46,47 +47,6 @@ static volatile int gli_window_alive = TRUE;
 #define kPointingHandCursor 3
 
 void wintick(CFRunLoopTimerRef timer, void *info);
-
-@protocol GargoyleApp
-- (BOOL) initWindow: (pid_t) processID
-              width: (unsigned int) width
-             height: (unsigned int) height;
-
-- (NSEvent *) getWindowEvent: (pid_t) processID;
-
-- (NSRect) getWindowSize: (pid_t) processID;
-
-- (NSString *) getWindowCharString: (pid_t) processID;
-
-- (BOOL) clearWindowCharString: (pid_t) processID;
-
-- (BOOL) setWindow: (pid_t) processID
-        charString: (NSEvent *) event;
-
-- (BOOL) setWindow: (pid_t) processID
-             title: (NSString *) title;
-
-- (BOOL) setWindow: (pid_t) processID
-          contents: (NSData *) frame
-             width: (unsigned int) width
-            height: (unsigned int) height;
-
-- (void) closeWindow: (pid_t) processID;
-
-- (NSString *) openWindowDialog: (pid_t) processID
-                         prompt: (NSString *) prompt
-                         filter: (unsigned int) filter;
-
-- (NSString *) saveWindowDialog: (pid_t) processID
-                         prompt: (NSString *) prompt
-                         filter: (unsigned int) filter;
-
-- (void) abortWindowDialog: (pid_t) processID
-                    prompt: (NSString *) prompt;
-
-- (void) setCursor: (unsigned int) cursor;
-
-@end
 
 @interface GargoyleMonitor : NSObject
 {
@@ -478,36 +438,6 @@ void winrefresh(void)
 
     gli_refresh_needed = !refreshed;
 }
-
-#define NSKEY_LEFT      0x7b
-#define NSKEY_RIGHT     0x7c
-#define NSKEY_DOWN      0x7d
-#define NSKEY_UP        0x7e
-
-#define NSKEY_X         0x07
-#define NSKEY_C         0x08
-#define NSKEY_V         0x09
-
-#define NSKEY_PGUP      0x74
-#define NSKEY_PGDN      0x79
-#define NSKEY_HOME      0x73
-#define NSKEY_END       0x77
-#define NSKEY_DEL       0x75
-#define NSKEY_BACK      0x33
-#define NSKEY_ESC       0x35
-
-#define NSKEY_F1        0x7a
-#define NSKEY_F2        0x78
-#define NSKEY_F3        0x63
-#define NSKEY_F4        0x76
-#define NSKEY_F5        0x60
-#define NSKEY_F6        0x61
-#define NSKEY_F7        0x62
-#define NSKEY_F8        0x64
-#define NSKEY_F9        0x65
-#define NSKEY_F10       0x6d
-#define NSKEY_F11       0x67
-#define NSKEY_F12       0x6f
 
 void winkey(NSEvent *evt)
 {


### PR DESCRIPTION
### Background

Gargoyle launcher process intercepts all events and forwards relevant events to the interpreter process (mostly key down events). The interpreter validates the raw event and then translates any key down events into character codes. To do the translation, the interpreter forwards the event back to the Gargoyle process using a remote connection (`NSConnection`). The Gargoyle process then feeds the event into an `NSTextView` object using the `interpretKeyEvents:` method. Later, the interpreter process retrieves the result string out of the text view and uses it as actual input.

### Problem

Feeding raw event objects into the text view when invoked via the interpreter's remote connection doesn't work in macOS 10.12 (see `GargoyleApp` class `sendChars:` method). The exact reason is unknown at this time (security enhancement?). All events are silently ignored/discarded by the `NSTextView` object.

### Workaround

Translate the key down events into characters when they are intercepted in the window's `sendEvent:` method. To maintain original behavior only the exact events the interpreter accepts as input characters are translated. The changes should work in older Mac OS X releases.
